### PR TITLE
Fix intel-oneapi builds of CAM that include changes from cam6_3_147 or newer

### DIFF
--- a/bld/configure
+++ b/bld/configure
@@ -1683,7 +1683,7 @@ elsif ($fc =~ /nvfor/)  { $fc_type = 'nvhpc'; }
 
 # User override for Fortran compiler type
 if (defined $opts{'fc_type'}) { $fc_type = $opts{'fc_type'}; }
-if ($fc_type eq "oneapi") {$fc_type = 'intel'; }
+if ($fc_type =~ /intel/) {$fc_type = 'intel'; }
 if ($fc_type) {
     $cfg_ref->set('fc_type', $fc_type);
     if ($print>=2) { print "Fortran compiler type: $fc_type$eol"; }


### PR DESCRIPTION
Fixes [EarthWorksOrg/EarthWorks #35](https://github.com/EarthWorksOrg/EarthWorks/issues/35) and [ESCOMP/CAM #988](https://github.com/ESCOMP/CAM/issues/988)

**Note:** This PR requires that [EarthWorksOrg/CAM #14](https://github.com/EarthWorksOrg/CAM/pull/14) is merged first, as it fixes problems introduced by integrating upstream tag cam6_3_147 as part of #14.