### PR TITLE
Changing RRTMGP repo link

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -89,8 +89,8 @@ externals = Externals_HCO.cfg
 [rte-rrtmgp]
 local_path = src/physics/rrtmgp/ext
 protocol = git
-repo_url = https://github.com/earth-system-radiation/rte-rrtmgp.git
-tag = v1.7
+repo_url = https://github.com/EarthWorksOrg/rte-rrtmgp.git
+tag = v1.7_ew_release_2.2
 required = True
 
 [rrtmgp-data]


### PR DESCRIPTION
From: https://github.com/earth-system-radiation/rte-rrtmgp.git Tag: v1.7
To: https://github.com/EarthWorksOrg/rte-rrtmgp.git Tag: v1.7_ew_release_2.2
This is a temporary measure for the functional release of Earthworks. This change fixes the GPU seg fault in RRTMGP because of the missing data directives in the CAM-RRTMGP interface. This change should be removed once we add the data directives to the CAM-RRTMGP interface.