### PR TITLE
Workaround issues with MPASv8 ncdata files for EarthWorks

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -3747,7 +3747,7 @@ if (!$simple_phys) {
 }
 
 if ($waccm_phys or
-    (!$simple_phys and $cfg->get('nlev') >= 60)) {
+    (!$simple_phys and $cfg->get('nlev') >= 60) and $dyn !~ /mpas/) {
     # Spectral gravity waves are part of WACCM physics, and also drive the
     # QBO in the high vertical resolution configuration.
     add_default($nl, 'use_gw_front'     , 'val'=>'.true.');
@@ -3770,7 +3770,7 @@ if ($waccm_phys or
     }
     add_default($nl, 'gw_qbo_hdepth_scaling', 'val'=>$hdepth_scaling);
     add_default($nl, 'gw_top_taper');
-} elsif ($phys =~ /cam_dev/) {
+} elsif ($phys =~ /cam_dev/ and $dyn !~ /mpas/) {
     # cam_dev settings for nlev<60 (Other cam_dev set above)
     add_default($nl, 'use_gw_front'     , 'val'=>'.true.');
     add_default($nl, 'use_gw_convect_dp', 'val'=>'.true.');

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -287,19 +287,19 @@
 <ncdata hgrid="mpasa120" nlev="70" waccm_phys="1">atm/waccm/ic/mpasa120km.waccm_fulltopo_c220818.nc</ncdata>
 
 <ncdata hgrid="mpasa480" nlev="32" ic_ymd="20000101" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa480_L32_CFSR_c211013.nc</ncdata>
-<ncdata hgrid="mpasa480" nlev="32" ic_ymd="20000101" phys="cam_dev" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa480_L32_CFSR_c240508.nc</ncdata>
+<!-- <ncdata hgrid="mpasa480" nlev="32" ic_ymd="20000101" phys="cam_dev" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa480_L32_CFSR_c240508.nc</ncdata> -->
 <ncdata hgrid="mpasa120" nlev="32" ic_ymd="20000101" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa120_L32_CFSR_c210426.nc</ncdata>
-<ncdata hgrid="mpasa120" nlev="32" ic_ymd="20000101" phys="cam_dev" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa120_L32_CFSR_c240508.nc</ncdata>
+<!-- <ncdata hgrid="mpasa120" nlev="32" ic_ymd="20000101" phys="cam_dev" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa120_L32_CFSR_c240508.nc</ncdata> -->
 <!-- Next 4 entries are EarthWorks specific, real-data ICs -->
 <ncdata hgrid="mpasa60"  nlev="32" ic_ymd="20000101" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa60_L32_CFSR_c210518.nc</ncdata>
-<ncdata hgrid="mpasa60"  nlev="32" ic_ymd="20000101" phys="cam_dev" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa60_L32_CFSR_c240508.nc</ncdata>
+<!-- <ncdata hgrid="mpasa60"  nlev="32" ic_ymd="20000101" phys="cam_dev" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa60_L32_CFSR_c240508.nc</ncdata> -->
 <ncdata hgrid="mpasa30"  nlev="32" ic_ymd="20000101" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa30_L32_CFSR_230302.nc</ncdata>
-<ncdata hgrid="mpasa60"  nlev="32" ic_ymd="20000101" phys="cam_dev" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa30_L32_CFSR_c240508.nc</ncdata>
+<!-- <ncdata hgrid="mpasa60"  nlev="32" ic_ymd="20000101" phys="cam_dev" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa30_L32_CFSR_c240508.nc</ncdata> -->
 <!-- Next 4 entries are EarthWorks specific, 58 vertical levels -->
 <ncdata hgrid="mpasa120" nlev="58" ic_ymd="20000101">atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa120_L58_c230901.nc</ncdata>
-<ncdata hgrid="mpasa120" nlev="58" ic_ymd="20000101" phys="cam_dev" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa120_L58_CFSR_c240508.nc</ncdata>
+<!-- <ncdata hgrid="mpasa120" nlev="58" ic_ymd="20000101" phys="cam_dev" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa120_L58_CFSR_c240508.nc</ncdata> -->
 <ncdata hgrid="mpasa15"  nlev="58" ic_ymd="20000101">atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa15_L58_c230316.nc</ncdata>
-<ncdata hgrid="mpasa15"  nlev="58" ic_ymd="20000101" phys="cam_dev" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa15_L58_CFSR_c240508.nc</ncdata>
+<!-- <ncdata hgrid="mpasa15"  nlev="58" ic_ymd="20000101" phys="cam_dev" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa15_L58_CFSR_c240508.nc</ncdata> -->
 
 <!-- Topography -->
 <bnd_topo hgrid="256x512" >atm/cam/topo/topo-from-cami_0000-01-01_256x512_L26_c030918.nc</bnd_topo>
@@ -357,19 +357,19 @@
 <bnd_topo hgrid="ne0np4.ARCTICGRIS.ne30x8" >atm/cam/topo/se/ne30x8_ARCTICGRIS_nc3000_Co060_Fi001_MulG_PF_RR_Nsw042_c200428.nc</bnd_topo>
 
 <bnd_topo hgrid="mpasa480" >atm/cam/topo/mpas_480_nc3000_Co240_Fi001_MulG_PF_Nsw170.nc</bnd_topo>
-<bnd_topo hgrid="mpasa480" phys="cam_dev" >atm/cam/topo/mpas/mpasa480_gmted2010_modis_bedmachine_nc3000_Laplace0400_noleak_20240507.nc</bnd_topo>
+<!-- <bnd_topo hgrid="mpasa480" phys="cam_dev" >atm/cam/topo/mpas/mpasa480_gmted2010_modis_bedmachine_nc3000_Laplace0400_noleak_20240507.nc</bnd_topo> -->
 <bnd_topo hgrid="mpasa120" >atm/cam/topo/mpas/mpas_120_nc3000_Co060_Fi001_MulG_PF_Nsw042_c200921.nc</bnd_topo>
-<bnd_topo hgrid="mpasa120" phys="cam_dev" >atm/cam/topo/mpas/mpasa120_gmted2010_modis_bedmachine_nc3000_Laplace0100_noleak_20240507.nc</bnd_topo>
+<!-- <bnd_topo hgrid="mpasa120" phys="cam_dev" >atm/cam/topo/mpas/mpasa120_gmted2010_modis_bedmachine_nc3000_Laplace0100_noleak_20240507.nc</bnd_topo> -->
 <!-- Next 3 entires are EarthWorks specific, for real-data cases not in ESCOMP/CAM -->
 <bnd_topo hgrid="mpasa60"  >atm/cam/topo/mpas_60_nc3000_Co030_Fi001_MulG_PF_Nsw021.nc</bnd_topo>
-<bnd_topo hgrid="mpasa60"  phys="cam_dev" >atm/cam/topo/mpas/mpasa60_gmted2010_modis_bedmachine_nc3000_Laplace0050_noleak_20240507.nc</bnd_topo>
+<!-- <bnd_topo hgrid="mpasa60"  phys="cam_dev" >atm/cam/topo/mpas/mpasa60_gmted2010_modis_bedmachine_nc3000_Laplace0050_noleak_20240507.nc</bnd_topo> -->
 <bnd_topo hgrid="mpasa30"  >atm/cam/topo/mpas_30_nc3000_Co015_Fi001_MulG_PF_Nsw011.nc</bnd_topo>
-<bnd_topo hgrid="mpasa30"  phys="cam_dev" >atm/cam/topo/mpas/mpasa30_gmted2010_modis_bedmachine_nc3000_Laplace0025_noleak_20240507.nc</bnd_topo>
+<!-- <bnd_topo hgrid="mpasa30"  phys="cam_dev" >atm/cam/topo/mpas/mpasa30_gmted2010_modis_bedmachine_nc3000_Laplace0025_noleak_20240507.nc</bnd_topo> -->
 <bnd_topo hgrid="mpasa15"  >atm/cam/topo/mpas_15_nc3500_c20230315.nc</bnd_topo>
-<bnd_topo hgrid="mpasa15"  phys="cam_dev" >atm/cam/topo/mpas/mpasa15_gmted2010_modis_bedmachine_nc3000_Laplace0013_noleak_20240507.nc</bnd_topo>
+<!-- <bnd_topo hgrid="mpasa15"  phys="cam_dev" >atm/cam/topo/mpas/mpasa15_gmted2010_modis_bedmachine_nc3000_Laplace0013_noleak_20240507.nc</bnd_topo> -->
 <!-- Corresponds to cami_01-01-2000_00Z_mpasa120_L58_c230901.nc file -->
 <bnd_topo hgrid="mpasa120" nlev="58" >atm/cam/topo/mpasa120_gmted2010_modis_bedmachine_nc3000_Laplace0100_20220728.nc</bnd_topo>
-<bnd_topo hgrid="mpasa120" nlev="58" phys="cam_dev" >atm/cam/topo/mpas/mpasa120_gmted2010_modis_bedmachine_nc3000_Laplace0100_noleak_20240507.nc</bnd_topo>
+<!-- <bnd_topo hgrid="mpasa120" nlev="58" phys="cam_dev" >atm/cam/topo/mpas/mpasa120_gmted2010_modis_bedmachine_nc3000_Laplace0100_noleak_20240507.nc</bnd_topo> -->
 
 <!-- Scale Dry Air Mass: 0=> no scaling / +nnn=>scale to nnn Pressure  -->
 <scale_dry_air_mass                                                                >      0.0D0 </scale_dry_air_mass>


### PR DESCRIPTION
This PR implements a workaround for run failures caused by files added in EarthWorksOrg/CAM #16 . The offending ncdata and bnd_topo files  are commented out and the previously existing MPAS ncdata files are made to work with cam_dev physics by adding `use_gw_front = .false.` to the default namelists.