### PR TITLE
Revert MPAS external to version without OpenACC

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -68,7 +68,7 @@ local_path = src/dynamics/mpas/dycore
 protocol = git
 repo_url = https://github.com/MPAS-Dev/MPAS-Model.git
 sparse = ../.mpas_sparse_checkout
-hash = b8c33daa
+hash = ff76a231
 required = True
 
 [geoschem]

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -66,9 +66,9 @@ required = True
 [mpas]
 local_path = src/dynamics/mpas/dycore
 protocol = git
-repo_url = https://github.com/EarthWorksOrg/MPAS-Model.git
+repo_url = https://github.com/MPAS-Dev/MPAS-Model.git
 sparse = ../.mpas_sparse_checkout
-tag = mpasa-ew2.2.000
+hash = b8c33daa
 required = True
 
 [geoschem]


### PR DESCRIPTION
Address correctness issues by reverting MPAS to a version without OpenACC. This is the same version that was used in tags  cam-ew2.0.003 and before (and in cam6_3_136 and before).