### PR TITLE
Eliminated additional data movement in RRTMGP

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -90,7 +90,7 @@ externals = Externals_HCO.cfg
 local_path = src/physics/rrtmgp/ext
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/rte-rrtmgp.git
-tag = v1.7_ew_release_2.2
+tag = v1.7_ew_release_2.3
 required = True
 
 [rrtmgp-data]


### PR DESCRIPTION
This is a follow-up for PR #24.  It reduces additional data movement in the rte_sw() and rte_lw() subroutines.  It also eliminates data movement within the calls to gas_optics() by moving the data movement outside of the subroutine call tree.  