### PR TITLE
Added more detailed timers

### DIFF
--- a/src/chemistry/modal_aero/aero_model.F90
+++ b/src/chemistry/modal_aero/aero_model.F90
@@ -1080,18 +1080,18 @@ contains
     ! 1) modal aerosols are affecting the climate, or
     ! 2) prognostic modal aerosols are enabled
 
-    call t_startf('aero_model_wetdep:CPU:calcsize')
+    call t_startf('aero_model_wetdep:NAR:calcsize')
     ! for prognostic modal aerosols the transfer of mass between aitken and accumulation
     ! modes is done in conjunction with the dry radius calculation
     call modal_aero_calcsize_sub(state, ptend, dt, pbuf)
-    call t_stopf('aero_model_wetdep:CPU:calcsize')
+    call t_stopf('aero_model_wetdep:NAR:calcsize')
 
-    call t_startf('aero_model_wetdep:CPU:wateruptake')
+    call t_startf('aero_model_wetdep:NAR:wateruptake')
     call modal_aero_wateruptake_dr(state, pbuf)
-    call t_stopf('aero_model_wetdep:CPU:wateruptake')
+    call t_stopf('aero_model_wetdep:NAR:wateruptake')
 
     if (nwetdep<1) return
-    call t_startf('aero_model_wetdep:CPU:wetdep')
+    call t_startf('aero_model_wetdep:NAR:wetdep')
 
     call wetdep_inputs_set( state, pbuf, dep_inputs )
 
@@ -1611,10 +1611,10 @@ contains
           enddo ! lspec = 0, nspec_amode(m)+1
        enddo ! lphase = 1, 2
     enddo ! m = 1, ntot_amode
-    call t_stopf('aero_model_wetdep:CPU:wetdep')
+    call t_stopf('aero_model_wetdep:NAR:wetdep')
 
     if (convproc_do_aer) then
-       call t_startf('aero_model_wetdep:CPU:ma_convproc')
+       call t_startf('aero_model_wetdep:NAR:ma_convproc')
        call ma_convproc_intr( state, ptend, pbuf, dt,                &
             nsrflx_mzaer2cnvpr, qsrflx_mzaer2cnvpr, aerdepwetis, &
             dcondt_resusp3d)
@@ -1646,7 +1646,7 @@ contains
           end do   ! m aerosol modes
        end if
 
-       call t_stopf('aero_model_wetdep:CPU:ma_convproc')
+       call t_stopf('aero_model_wetdep:NAR:ma_convproc')
     endif
 
     ! if the user has specified prescribed aerosol dep fluxes then

--- a/src/chemistry/modal_aero/aero_model.F90
+++ b/src/chemistry/modal_aero/aero_model.F90
@@ -1080,17 +1080,18 @@ contains
     ! 1) modal aerosols are affecting the climate, or
     ! 2) prognostic modal aerosols are enabled
 
-    call t_startf('calcsize')
+    call t_startf('aero_model_wetdep:CPU:calcsize')
     ! for prognostic modal aerosols the transfer of mass between aitken and accumulation
     ! modes is done in conjunction with the dry radius calculation
     call modal_aero_calcsize_sub(state, ptend, dt, pbuf)
-    call t_stopf('calcsize')
+    call t_stopf('aero_model_wetdep:CPU:calcsize')
 
-    call t_startf('wateruptake')
+    call t_startf('aero_model_wetdep:CPU:wateruptake')
     call modal_aero_wateruptake_dr(state, pbuf)
-    call t_stopf('wateruptake')
+    call t_stopf('aero_model_wetdep:CPU:wateruptake')
 
     if (nwetdep<1) return
+    call t_startf('aero_model_wetdep:CPU:wetdep')
 
     call wetdep_inputs_set( state, pbuf, dep_inputs )
 
@@ -1610,9 +1611,10 @@ contains
           enddo ! lspec = 0, nspec_amode(m)+1
        enddo ! lphase = 1, 2
     enddo ! m = 1, ntot_amode
+    call t_stopf('aero_model_wetdep:CPU:wetdep')
 
     if (convproc_do_aer) then
-       call t_startf('ma_convproc')
+       call t_startf('aero_model_wetdep:CPU:ma_convproc')
        call ma_convproc_intr( state, ptend, pbuf, dt,                &
             nsrflx_mzaer2cnvpr, qsrflx_mzaer2cnvpr, aerdepwetis, &
             dcondt_resusp3d)
@@ -1644,7 +1646,7 @@ contains
           end do   ! m aerosol modes
        end if
 
-       call t_stopf('ma_convproc')
+       call t_stopf('aero_model_wetdep:CPU:ma_convproc')
     endif
 
     ! if the user has specified prescribed aerosol dep fluxes then

--- a/src/physics/cam/clubb_intr.F90
+++ b/src/physics/cam/clubb_intr.F90
@@ -1990,7 +1990,7 @@ end subroutine clubb_init_cnst
     use macrop_driver,             only: liquid_macro_tend
     use clubb_mf,                  only: integrate_mf
 
-    use perf_mod
+    use perf_mod,                  only: t_startf, t_stopf
 
 #endif
 

--- a/src/physics/cam/micro_pumas_cam.F90
+++ b/src/physics/cam/micro_pumas_cam.F90
@@ -1380,7 +1380,7 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
    use tropopause,      only: tropopause_find, TROP_ALG_CPP, TROP_ALG_NONE, NOTFOUND
    use wv_saturation,   only: qsat
    use infnan,          only: nan, assignment(=)
-   use perf_mod
+   use perf_mod,        only: t_startf, t_stopf
 
    type(physics_state),         intent(in)    :: state
    type(physics_ptend),         intent(out)   :: ptend

--- a/src/physics/cam/micro_pumas_cam.F90
+++ b/src/physics/cam/micro_pumas_cam.F90
@@ -1836,7 +1836,7 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
    real(r8), parameter :: deicon = 50._r8            ! Convective ice effective diameter (meters)
 
    !-------------------------------------------------------------------------------
-   call t_startf('micro_pumas_cam_tend:CPU')
+   call t_startf('micro_pumas_cam_tend:NAR')
    lchnk = state%lchnk
    ncol  = state%ncol
    psetcols = state%psetcols
@@ -2266,7 +2266,7 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
    frzimm(:ncol,:top_lev-1)=0._r8
    frzcnt(:ncol,:top_lev-1)=0._r8
    frzdep(:ncol,:top_lev-1)=0._r8
-   call t_stopf('micro_pumas_cam_tend:CPU')
+   call t_stopf('micro_pumas_cam_tend:NAR')
 
    do it = 1, num_steps
 
@@ -2274,7 +2274,7 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
       case (1)
          select case (micro_mg_sub_version)
          case (0)
-            call t_startf('micro_mg_tend1_0:CPU')
+            call t_startf('micro_mg_tend1_0:NAR')
             call micro_mg_tend1_0( &
                  microp_uniform, ncol, nlev, ncol, 1, dtime/num_steps, &
                  state_loc%t(:ncol,top_lev:), state_loc%q(:ncol,top_lev:,ixq), state_loc%q(:ncol,top_lev:,ixcldliq), &
@@ -2313,7 +2313,7 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
                  nfice(:ncol,top_lev:), prer_evap(:ncol,top_lev:), do_cldice, errstring,                      &
                  tnd_qsnow(:ncol,top_lev:), tnd_nsnow(:ncol,top_lev:), re_ice(:ncol,top_lev:),             &
                  frzimm(:ncol,top_lev:), frzcnt(:ncol,top_lev:), frzdep(:ncol,top_lev:))
-            call t_stopf('micro_mg_tend1_0:CPU')
+            call t_stopf('micro_mg_tend1_0:NAR')
 
          end select
       case(2:3)
@@ -2389,7 +2389,7 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
          call t_stopf('micro_pumas_tend')
       end select
 
-      call t_startf('micro_pumas_cam_tend:CPU')
+      call t_startf('micro_pumas_cam_tend:NAR')
       call handle_errmsg(errstring, subname="micro_pumas_tend")
 
       call physics_ptend_init(ptend_loc, psetcols, "micro_pumas", &
@@ -2430,10 +2430,10 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
 
       ! Update local state
       call physics_update(state_loc, ptend_loc, dtime/num_steps)
-      call t_stopf('micro_pumas_cam_tend:CPU')
+      call t_stopf('micro_pumas_cam_tend:NAR')
 
    end do
-   call t_startf('micro_pumas_cam_tend:CPU')
+   call t_startf('micro_pumas_cam_tend:NAR')
 
    ! Divide ptend by substeps.
    call physics_ptend_scale(ptend, 1._r8/num_steps, ncol)
@@ -2865,24 +2865,24 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
    rel_fn_grid = 10._r8
 
    ncic_grid = 1.e8_r8
-   call t_stopf('micro_pumas_cam_tend:CPU')
+   call t_stopf('micro_pumas_cam_tend:NAR')
 
    do k = top_lev, pver
-      call t_startf('micro_pumas_cam_tend:H2D')
+      call t_startf('micro_pumas_cam_tend:DTO')
       !$acc data copyin  (mg_liq_props,icwmrst_grid(:ngrdcol,k),rho_grid(:ngrdcol,k)) &
       !$acc      copy    (ncic_grid(:ngrdcol,k)) &
       !$acc      copyout (mu_grid(:ngrdcol,k),lambdac_grid(:ngrdcol,k))
-      call t_stopf('micro_pumas_cam_tend:H2D')
-      call t_startf('micro_pumas_cam_tend:GPU')
+      call t_stopf('micro_pumas_cam_tend:DTO')
+      call t_startf('micro_pumas_cam_tend:ACCR')
       call size_dist_param_liq(mg_liq_props, icwmrst_grid(:ngrdcol,k), &
                                ncic_grid(:ngrdcol,k), rho_grid(:ngrdcol,k), &
                                mu_grid(:ngrdcol,k), lambdac_grid(:ngrdcol,k), ngrdcol)
-      call t_stopf('micro_pumas_cam_tend:GPU')
-      call t_startf('micro_pumas_cam_tend:D2H')
+      call t_stopf('micro_pumas_cam_tend:ACCR')
+      call t_startf('micro_pumas_cam_tend:DTO')
       !$acc end data
-      call t_stopf('micro_pumas_cam_tend:D2H')
+      call t_stopf('micro_pumas_cam_tend:DTO')
    end do
-   call t_startf('micro_pumas_cam_tend:CPU')
+   call t_startf('micro_pumas_cam_tend:NAR')
 
    where (icwmrst_grid(:ngrdcol,top_lev:) > qsmall)
       rel_fn_grid(:ngrdcol,top_lev:) = &
@@ -2899,24 +2899,24 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
    ! Calculate ncic on the grid
    ncic_grid(:ngrdcol,top_lev:) = nc_grid(:ngrdcol,top_lev:) / &
         max(mincld,liqcldf_grid(:ngrdcol,top_lev:))
-   call t_stopf('micro_pumas_cam_tend:CPU')
+   call t_stopf('micro_pumas_cam_tend:NAR')
 
    do k = top_lev, pver
-      call t_startf('micro_pumas_cam_tend:H2D')
+      call t_startf('micro_pumas_cam_tend:DTO')
       !$acc data copyin  (mg_liq_props,icwmrst_grid(:ngrdcol,k), rho_grid(:ngrdcol,k)) &
       !$acc      copy    (ncic_grid(:ngrdcol,k)) &
       !$acc      copyout (mu_grid(:ngrdcol,k),lambdac_grid(:ngrdcol,k))
-      call t_stopf('micro_pumas_cam_tend:H2D')
-      call t_startf('micro_pumas_cam_tend:GPU')
+      call t_stopf('micro_pumas_cam_tend:DTO')
+      call t_startf('micro_pumas_cam_tend:ACCR')
       call size_dist_param_liq(mg_liq_props, icwmrst_grid(:ngrdcol,k), &
            ncic_grid(:ngrdcol,k), rho_grid(:ngrdcol,k), &
            mu_grid(:ngrdcol,k), lambdac_grid(:ngrdcol,k), ngrdcol)
-      call t_stopf('micro_pumas_cam_tend:GPU')
-      call t_startf('micro_pumas_cam_tend:D2H')
+      call t_stopf('micro_pumas_cam_tend:ACCR')
+      call t_startf('micro_pumas_cam_tend:DTO')
       !$acc end data
-      call t_stopf('micro_pumas_cam_tend:D2H')
+      call t_stopf('micro_pumas_cam_tend:DTO')
    end do
-   call t_startf('micro_pumas_cam_tend:CPU')
+   call t_startf('micro_pumas_cam_tend:NAR')
 
    where (icwmrst_grid(:ngrdcol,top_lev:) >= qsmall)
       rel_grid(:ngrdcol,top_lev:) = &
@@ -3011,24 +3011,24 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
 
    niic_grid(:ngrdcol,top_lev:) = ni_grid(:ngrdcol,top_lev:) / &
         max(mincld,icecldf_grid(:ngrdcol,top_lev:))
-   call t_stopf('micro_pumas_cam_tend:CPU')
+   call t_stopf('micro_pumas_cam_tend:NAR')
 
    do k = top_lev, pver
-      call t_startf('micro_pumas_cam_tend:H2D')
+      call t_startf('micro_pumas_cam_tend:DTO')
       !$acc data copyin  (mg_ice_props, icimrst_grid(:ngrdcol,k)) &
       !$acc      copy    (niic_grid(:ngrdcol,k)) &
       !$acc      copyout (rei_grid(:ngrdcol,k))
-      call t_stopf('micro_pumas_cam_tend:H2D')
-      call t_startf('micro_pumas_cam_tend:GPU')
+      call t_stopf('micro_pumas_cam_tend:DTO')
+      call t_startf('micro_pumas_cam_tend:ACCR')
       call size_dist_param_basic(mg_ice_props,icimrst_grid(:ngrdcol,k), &
                                  niic_grid(:ngrdcol,k),rei_grid(:ngrdcol,k),ngrdcol)
-      call t_stopf('micro_pumas_cam_tend:GPU')
-      call t_startf('micro_pumas_cam_tend:D2H')
+      call t_stopf('micro_pumas_cam_tend:ACCR')
+      call t_startf('micro_pumas_cam_tend:DTO')
       !$acc end data
-      call t_stopf('micro_pumas_cam_tend:D2H')
+      call t_stopf('micro_pumas_cam_tend:DTO')
    end do
 
-   call t_startf('micro_pumas_cam_tend:CPU')
+   call t_startf('micro_pumas_cam_tend:NAR')
    where (icimrst_grid(:ngrdcol,top_lev:) >= qsmall)
       rei_grid(:ngrdcol,top_lev:) = 1.5_r8/rei_grid(:ngrdcol,top_lev:) &
            * 1.e6_r8
@@ -3500,7 +3500,7 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
    if (qsatfac_idx <= 0) then
       deallocate(qsatfac)
    end if
-   call t_stopf('micro_pumas_cam_tend:CPU')
+   call t_stopf('micro_pumas_cam_tend:NAR')
 
 end subroutine micro_pumas_cam_tend
 

--- a/src/physics/cam/microp_aero.F90
+++ b/src/physics/cam/microp_aero.F90
@@ -53,6 +53,7 @@ use modal_aerosol_properties_mod, only: modal_aerosol_properties
 
 use aerosol_state_mod, only: aerosol_state
 use modal_aerosol_state_mod, only: modal_aerosol_state
+use perf_mod, only: t_startf, t_stopf
 
 implicit none
 private

--- a/src/physics/cam/microp_driver.F90
+++ b/src/physics/cam/microp_driver.F90
@@ -185,9 +185,9 @@ subroutine microp_driver_tend(state, ptend, dtime, pbuf)
 
    select case (microp_scheme)
    case ('MG')
-      call t_startf('microp_mg_tend')
+      call t_startf('microp_driver_tend:micro_pumas_cam_tend')
       call micro_pumas_cam_tend(state, ptend, dtime, pbuf)
-      call t_stopf('microp_mg_tend')
+      call t_stopf('microp_driver_tend:micro_pumas_cam_tend')
    case ('RK')
       ! microp_driver doesn't handle this one
       continue

--- a/src/physics/cam/physpkg.F90
+++ b/src/physics/cam/physpkg.F90
@@ -28,7 +28,7 @@ module physpkg
   use phys_control,     only: phys_do_flux_avg, phys_getopts, waccmx_is
   use scamMod,          only: single_column, scm_crm_mode
   use flux_avg,         only: flux_avg_init
-  use perf_mod
+  use perf_mod,         only: t_startf, t_stopf, t_barrierf, t_adj_detailf
   use cam_logfile,     only: iulog
   use camsrfexch,      only: cam_export
 
@@ -1420,7 +1420,7 @@ contains
     use charge_neutrality,  only: charge_balance
     use qbo,                only: qbo_relax
     use iondrag,            only: iondrag_calc, do_waccm_ions
-    use perf_mod
+    use perf_mod,           only: t_startf, t_stopf
     use flux_avg,           only: flux_avg_run
     use unicon_cam,         only: unicon_cam_org_diags
     use cam_history,        only: outfld
@@ -2072,7 +2072,7 @@ contains
     use carma_flags_mod, only: carma_do_detrain, carma_do_cldice, carma_do_cldliq,  carma_do_wetdep
     use radiation,       only: radiation_tend
     use cloud_diagnostics, only: cloud_diagnostics_calc
-    use perf_mod
+    use perf_mod,        only: t_startf, t_stopf
     use mo_gas_phase_chemdr,only: map2chm
     use clybry_fam,         only: clybry_fam_adj
     use clubb_intr,      only: clubb_tend_cam
@@ -2938,7 +2938,7 @@ subroutine phys_timestep_init(phys_state, cam_in, cam_out, pbuf2d)
   use solar_data,          only: solar_data_advance
   use qbo,                 only: qbo_timestep_init
   use iondrag,             only: do_waccm_ions, iondrag_timestep_init
-  use perf_mod
+  use perf_mod,            only: t_startf, t_stopf
 
   use prescribed_ozone,    only: prescribed_ozone_adv
   use prescribed_ghg,      only: prescribed_ghg_adv

--- a/src/physics/cam/physpkg.F90
+++ b/src/physics/cam/physpkg.F90
@@ -1569,7 +1569,7 @@ contains
     !===================================================
     ! Source/sink terms for advected tracers.
     !===================================================
-    call t_startf('adv_tracer_src_snk')
+    call t_startf('tphysac:chem_timestep_tend')
     ! Test tracers
 
     if (trim(cam_take_snapshot_before) == "aoa_tracers_timestep_tend") then
@@ -1638,14 +1638,14 @@ contains
        call check_tracers_chng(state, tracerint, "chem_timestep_tend", nstep, ztodt, &
             cam_in%cflx)
     end if
-    call t_stopf('adv_tracer_src_snk')
+    call t_stopf('tphysac:chem_timestep_tend')
 
     !===================================================
     ! Vertical diffusion/pbl calculation
     ! Call vertical diffusion code (pbl, free atmosphere and molecular)
     !===================================================
 
-    call t_startf('vertical_diffusion_tend')
+    call t_startf('tphysac:vertical_diffusion_tend')
 
     if (trim(cam_take_snapshot_before) == "vertical_diffusion_section") then
        call cam_snapshot_all_outfld_tphysac(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf,&
@@ -1679,12 +1679,12 @@ contains
                     fh2o, surfric, obklen, flx_heat)
     end if
 
-    call t_stopf ('vertical_diffusion_tend')
+    call t_stopf ('tphysac:vertical_diffusion_tend')
 
     !===================================================
     ! Rayleigh friction calculation
     !===================================================
-    call t_startf('rayleigh_friction')
+    call t_startf('tphysac:rayleigh_friction_tend')
     call rayleigh_friction_tend( ztodt, state, ptend)
     if ( ptend%lu ) then
       call outfld( 'UTEND_RAYLEIGH', ptend%u, pcols, lchnk)
@@ -1693,7 +1693,7 @@ contains
       call outfld( 'VTEND_RAYLEIGH', ptend%v, pcols, lchnk)
     end if
     call physics_update(state, ptend, ztodt, tend)
-    call t_stopf('rayleigh_friction')
+    call t_stopf('tphysac:rayleigh_friction_tend')
 
     if (do_clubb_sgs) then
       call check_energy_chng(state, tend, "vdiff", nstep, ztodt, zero, zero, zero, zero)
@@ -1705,7 +1705,7 @@ contains
     call check_tracers_chng(state, tracerint, "vdiff", nstep, ztodt, cam_in%cflx)
 
     !  aerosol dry deposition processes
-    call t_startf('aero_drydep')
+    call t_startf('tphysac:aero_model_drydep')
 
     if (trim(cam_take_snapshot_before) == "aero_model_drydep") then
        call cam_snapshot_all_outfld_tphysac(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf,&
@@ -1724,7 +1724,7 @@ contains
                     fh2o, surfric, obklen, flx_heat)
    end if
 
-    call t_stopf('aero_drydep')
+    call t_stopf('tphysac:aero_model_drydep')
 
    ! CARMA microphysics
    !
@@ -1734,12 +1734,12 @@ contains
    ! that cam_out%xxxdryxxx fields have already been set for CAM aerosols and cam_out
    ! can be added to for CARMA aerosols.
    if (carma_do_aerosol) then
-     call t_startf('carma_timestep_tend')
+     call t_startf('tphysac:carma_timestep_tend')
      call carma_timestep_tend(state, cam_in, cam_out, ptend, ztodt, pbuf, obklen=obklen, ustar=surfric)
      call physics_update(state, ptend, ztodt, tend)
 
      call check_energy_chng(state, tend, "carma_tend", nstep, ztodt, zero, zero, zero, zero)
-     call t_stopf('carma_timestep_tend')
+     call t_stopf('tphysac:carma_timestep_tend')
    end if
 
 
@@ -1751,7 +1751,7 @@ contains
     !===================================================
     ! Gravity wave drag
     !===================================================
-    call t_startf('gw_tend')
+    call t_startf('tphysac:gw_tend')
 
     if (trim(cam_take_snapshot_before) == "gw_tend") then
        call cam_snapshot_all_outfld_tphysac(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf,&
@@ -1780,7 +1780,7 @@ contains
     ! Check energy integrals
     call check_energy_chng(state, tend, "gwdrag", nstep, ztodt, zero, &
          zero, zero, flx_heat)
-    call t_stopf('gw_tend')
+    call t_stopf('tphysac:gw_tend')
 
     ! QBO relaxation
 
@@ -1823,7 +1823,7 @@ contains
     call check_energy_chng(state, tend, "lunar_tides", nstep, ztodt, zero, zero, zero, zero)
 
     ! Ion drag calculation
-    call t_startf ( 'iondrag' )
+    call t_startf ( 'tphysac:iondrag' )
 
     if (trim(cam_take_snapshot_before) == "iondrag_calc_section") then
        call cam_snapshot_all_outfld_tphysac(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf,&
@@ -1872,7 +1872,7 @@ contains
     ! Check energy integrals
     call check_energy_chng(state, tend, "iondrag", nstep, ztodt, zero, zero, zero, zero)
 
-    call t_stopf  ( 'iondrag' )
+    call t_stopf  ( 'tphysac:iondrag' )
 
     ! Update Nudging values, if needed
     !----------------------------------
@@ -2200,7 +2200,7 @@ contains
 
     !-----------------------------------------------------------------------
 
-    call t_startf('bc_init')
+    call t_startf('tphysbc:bc_init')
 
     zero = 0._r8
     zero_tracers(:,:) = 0._r8
@@ -2263,12 +2263,12 @@ contains
     ! compute mass integrals of input tracers state
     call check_tracers_init(state, tracerint)
 
-    call t_stopf('bc_init')
+    call t_stopf('tphysbc:bc_init')
 
     !===================================================
     ! Global mean total energy fixer
     !===================================================
-    call t_startf('energy_fixer')
+    call t_startf('tphysbc:energy_fixer')
 
     call tot_energy_phys(state, 'phBF')
     call tot_energy_phys(state, 'dyBF',vc=vc_dycore)
@@ -2318,12 +2318,12 @@ contains
        call outfld( 'VTEND_CORE', dvcore, pcols, lchnk )
     end if
 
-    call t_stopf('energy_fixer')
+    call t_stopf('tphysbc:energy_fixer')
     !
     !===================================================
     ! Dry adjustment
     !===================================================
-    call t_startf('dry_adjustment')
+    call t_startf('tphysbc:dry_adjustment')
 
     if (trim(cam_take_snapshot_before) == "dadadj_tend") then
        call cam_snapshot_all_outfld_tphysbc(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf, &
@@ -2343,14 +2343,14 @@ contains
            flx_heat, cmfmc, cmfcme, pflx, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
     end if
 
-    call t_stopf('dry_adjustment')
+    call t_stopf('tphysbc:dry_adjustment')
 
     !===================================================
     ! Moist convection
     !===================================================
-    call t_startf('moist_convection')
+    !call t_startf('moist_convection')
 
-    call t_startf ('convect_deep_tend')
+    call t_startf ('tphysbc:convect_deep_tend')
 
     if (trim(cam_take_snapshot_before) == "convect_deep_tend") then
        call cam_snapshot_all_outfld_tphysbc(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf, &
@@ -2382,7 +2382,7 @@ contains
            flx_heat, cmfmc, cmfcme, pflx, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
     end if
 
-    call t_stopf('convect_deep_tend')
+    call t_stopf('tphysbc:convect_deep_tend')
 
     call pbuf_get_field(pbuf, prec_dp_idx, prec_dp )
     call pbuf_get_field(pbuf, snow_dp_idx, snow_dp )
@@ -2409,7 +2409,7 @@ contains
     !
     ! Call Hack (1994) convection scheme to deal with shallow/mid-level convection
     !
-    call t_startf ('convect_shallow_tend')
+    call t_startf ('tphysbc:convect_shallow_tend')
 
     if (dlfzm_idx > 0) then
        call pbuf_get_field(pbuf, dlfzm_idx, dlfzm)
@@ -2426,7 +2426,7 @@ contains
     call convect_shallow_tend (ztodt   , cmfmc, &
          dlf        , dlf2   ,  rliq   , rliq2, &
          state      , ptend  ,  pbuf, cam_in)
-    call t_stopf ('convect_shallow_tend')
+    call t_stopf ('tphysbc:convect_shallow_tend')
 
     if ( (trim(cam_take_snapshot_after) == "convect_shallow_tend") .and. &
          (trim(cam_take_snapshot_before) == trim(cam_take_snapshot_after))) then
@@ -2450,7 +2450,7 @@ contains
 
     call check_tracers_chng(state, tracerint, "convect_shallow", nstep, ztodt, zero_tracers)
 
-    call t_stopf('moist_convection')
+    !call t_stopf('moist_convection')
 
     ! Rebin the 4-bin version of sea salt into bins for coarse and accumulation
     ! modes that correspond to the available optics data.  This is only necessary
@@ -2468,7 +2468,7 @@ contains
     ! snow are stored in the physics buffer and will be incorporated by the MG microphysics.
     !
     ! Currently CARMA cloud microphysics is only supported with the MG microphysics.
-    call t_startf('carma_timestep_tend')
+    call t_startf('tphysbc:carma_timestep_tend')
 
     if (carma_do_cldice .or. carma_do_cldliq) then
        call carma_timestep_tend(state, cam_in, cam_out, ptend, ztodt, pbuf, dlf=dlf, rliq=rliq, &
@@ -2484,14 +2484,14 @@ contains
        end if
     end if
 
-    call t_stopf('carma_timestep_tend')
+    call t_stopf('tphysbc:carma_timestep_tend')
 
     if( microp_scheme == 'RK' ) then
 
        !===================================================
        ! Calculate stratiform tendency (sedimentation, detrain, cloud fraction and microphysics )
        !===================================================
-       call t_startf('rk_stratiform_tend')
+       call t_startf('tphysbc:rk_stratiform_tend')
 
        call rk_stratiform_tend(state, ptend, pbuf, ztodt, &
             cam_in%icefrac, cam_in%landfrac, cam_in%ocnfrac, &
@@ -2504,7 +2504,7 @@ contains
        call physics_update(state, ptend, ztodt, tend)
        call check_energy_chng(state, tend, "cldwat_tend", nstep, ztodt, zero, prec_str, snow_str, zero)
 
-       call t_stopf('rk_stratiform_tend')
+       call t_stopf('tphysbc:rk_stratiform_tend')
 
     elseif( microp_scheme == 'MG' ) then
        ! Start co-substepping of macrophysics and microphysics
@@ -2533,7 +2533,7 @@ contains
           ! Calculate macrophysical tendency (sedimentation, detrain, cloud fraction)
           !===================================================
 
-          call t_startf('macrop_tend')
+          call t_startf('tphysbc:macrop_tend')
 
           ! don't call Park macrophysics if CLUBB is called
           if (macrop_scheme .ne. 'CLUBB_SGS') then
@@ -2629,7 +2629,7 @@ contains
 
           endif
 
-          call t_stopf('macrop_tend')
+          call t_stopf('tphysbc:macrop_tend')
 
           !===================================================
           ! Calculate cloud microphysics
@@ -2657,11 +2657,11 @@ contains
                   flx_heat, cmfmc, cmfcme, pflx, zdu, rliq, rice, dlf, dlf2, rliq2, det_s, det_ice, net_flx)
           end if
 
-          call t_startf('microp_aero_run')
+          call t_startf('tphysbc:microp_aero_run')
           call microp_aero_run(state, ptend_aero, cld_macmic_ztodt, pbuf)
-          call t_stopf('microp_aero_run')
+          call t_stopf('tphysbc:microp_aero_run')
 
-          call t_startf('microp_tend')
+          call t_startf('tphysbc:microp_tend')
 
           if (use_subcol_microp) then
 
@@ -2758,7 +2758,7 @@ contains
                zero, prec_str(:ncol)/cld_macmic_num_steps, &
                snow_str(:ncol)/cld_macmic_num_steps, zero)
 
-          call t_stopf('microp_tend')
+          call t_stopf('tphysbc:microp_tend')
           prec_sed_macmic(:ncol) = prec_sed_macmic(:ncol) + prec_sed(:ncol)
           snow_sed_macmic(:ncol) = snow_sed_macmic(:ncol) + snow_sed(:ncol)
           prec_pcw_macmic(:ncol) = prec_pcw_macmic(:ncol) + prec_pcw(:ncol)
@@ -2798,7 +2798,7 @@ contains
        !    wet scavenging but not 'convect_deep_tend2'.
        ! -------------------------------------------------------------------------------
 
-       call t_startf('bc_aerosols')
+       call t_startf('tphysbc:bc_aerosols')
        if (clim_modal_aero .and. .not. prog_modal_aero) then
           call modal_aero_calcsize_diag(state, pbuf)
           call modal_aero_wateruptake_dr(state, pbuf)
@@ -2827,21 +2827,21 @@ contains
           ! NOTE: It needs to follow aero_model_wetdep, so that cam_out%xxxwetxxx
           ! fields have already been set for CAM aerosols and cam_out can be added
           ! to for CARMA aerosols.
-          call t_startf ('carma_wetdep_tend')
+          call t_startf ('tphysbc:carma_wetdep_tend')
           call carma_wetdep_tend(state, ptend, ztodt, pbuf, dlf, cam_out)
           call physics_update(state, ptend, ztodt, tend)
-          call t_stopf ('carma_wetdep_tend')
+          call t_stopf ('tphysbc:carma_wetdep_tend')
        end if
 
-       call t_startf ('convect_deep_tend2')
+       call t_startf ('tphysbc:convect_deep_tend2')
        call convect_deep_tend_2( state,   ptend,  ztodt,  pbuf )
        call physics_update(state, ptend, ztodt, tend)
-       call t_stopf ('convect_deep_tend2')
+       call t_stopf ('tphysbc:convect_deep_tend2')
 
        ! check tracer integrals
        call check_tracers_chng(state, tracerint, "cmfmca", nstep, ztodt,  zero_tracers)
 
-       call t_stopf('bc_aerosols')
+       call t_stopf('tphysbc:bc_aerosols')
 
    endif
 
@@ -2869,7 +2869,7 @@ contains
     !===================================================
     ! Radiation computations
     !===================================================
-    call t_startf('radiation')
+    call t_startf('tphysbc:radiation_tend')
 
     if (trim(cam_take_snapshot_before) == "radiation_tend") then
        call cam_snapshot_all_outfld_tphysbc(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf, &
@@ -2897,7 +2897,7 @@ contains
 
     call check_energy_chng(state, tend, "radheat", nstep, ztodt, zero, zero, zero, net_flx)
 
-    call t_stopf('radiation')
+    call t_stopf('tphysbc:radiation_tend')
 
     ! Diagnose the location of the tropopause and its location to the history file(s).
     call t_startf('tropopause')

--- a/src/physics/cam_dev/micro_pumas_cam.F90
+++ b/src/physics/cam_dev/micro_pumas_cam.F90
@@ -1895,7 +1895,7 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
 
    nan_array = nan
 
-   call t_startf('micro_pumas_cam_tend:CPU')
+   call t_startf('micro_pumas_cam_tend:NAR')
    ! Allocate the proc_rates DDT
    ! IMPORTANT NOTE -- elements in proc_rates are dimensioned to the nlev dimension while
    !     all the other arrays in this routine are dimensioned pver.  This is required because
@@ -2281,7 +2281,7 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
    frzimm(:ncol,:top_lev-1)=0._r8
    frzcnt(:ncol,:top_lev-1)=0._r8
    frzdep(:ncol,:top_lev-1)=0._r8
-   call t_stopf('micro_pumas_cam_tend:CPU')
+   call t_stopf('micro_pumas_cam_tend:NAR')
 
    do it = 1, num_steps
 
@@ -2337,7 +2337,7 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
               prer_evap(:ncol,top_lev:),                                     &
               frzimm(:ncol,top_lev:),  frzcnt(:ncol,top_lev:),  frzdep(:ncol,top_lev:)   )
       call t_stopf('micro_pumas_cam_tend:micro_pumas_tend')
-      call t_startf('micro_pumas_cam_tend:CPU')
+      call t_startf('micro_pumas_cam_tend:NAR')
 
       call handle_errmsg(errstring, subname="micro_pumas_cam_tend")
 
@@ -2387,11 +2387,11 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
          proc_rates%ank(:ncol,:,:) = proc_rates%ank(:ncol,:,:)/num_steps
          proc_rates%amk_out(:ncol,:,:) = proc_rates%amk_out(:ncol,:,:)/num_steps
       end if
-      call t_stopf('micro_pumas_cam_tend:CPU')
+      call t_stopf('micro_pumas_cam_tend:NAR')
 
    end do
 
-   call t_startf('micro_pumas_cam_tend:CPU')
+   call t_startf('micro_pumas_cam_tend:NAR')
    ! Divide ptend by substeps.
    call physics_ptend_scale(ptend, 1._r8/num_steps, ncol)
 
@@ -2858,24 +2858,24 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
    rel_fn_grid = 10._r8
 
    ncic_grid = 1.e8_r8
-   call t_stopf('micro_pumas_cam_tend:CPU')
+   call t_stopf('micro_pumas_cam_tend:NAR')
 
    do k = top_lev, pver
-      call t_startf('micro_pumas_cam_tend:H2D')
+      call t_startf('micro_pumas_cam_tend:DTO')
       !$acc data copyin  (mg_liq_props,icwmrst_grid(:ngrdcol,k),rho_grid(:ngrdcol,k)) &
       !$acc      copy    (ncic_grid(:ngrdcol,k)) &
       !$acc      copyout (mu_grid(:ngrdcol,k),lambdac_grid(:ngrdcol,k))
-      call t_stopf('micro_pumas_cam_tend:H2D')
-      call t_startf('micro_pumas_cam_tend:GPU')
+      call t_stopf('micro_pumas_cam_tend:DTO')
+      call t_startf('micro_pumas_cam_tend:ACCR')
       call size_dist_param_liq(mg_liq_props, icwmrst_grid(:ngrdcol,k), &
                                ncic_grid(:ngrdcol,k), rho_grid(:ngrdcol,k), &
                                mu_grid(:ngrdcol,k), lambdac_grid(:ngrdcol,k), ngrdcol)
-      call t_stopf('micro_pumas_cam_tend:GPU')
-      call t_startf('micro_pumas_cam_tend:D2H')
+      call t_stopf('micro_pumas_cam_tend:ACCR')
+      call t_startf('micro_pumas_cam_tend:DTO')
       !$acc end data
-      call t_stopf('micro_pumas_cam_tend:D2H')
+      call t_stopf('micro_pumas_cam_tend:DTO')
    end do
-   call t_startf('micro_pumas_cam_tend:CPU')
+   call t_startf('micro_pumas_cam_tend:NAR')
 
    where (icwmrst_grid(:ngrdcol,top_lev:) > qsmall)
       rel_fn_grid(:ngrdcol,top_lev:) = &
@@ -2892,24 +2892,24 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
    ! Calculate ncic on the grid
    ncic_grid(:ngrdcol,top_lev:) = nc_grid(:ngrdcol,top_lev:) / &
         max(mincld,liqcldf_grid(:ngrdcol,top_lev:))
-   call t_stopf('micro_pumas_cam_tend:CPU')
+   call t_stopf('micro_pumas_cam_tend:NAR')
 
    do k = top_lev, pver
-      call t_startf('micro_pumas_cam_tend:H2D')
+      call t_startf('micro_pumas_cam_tend:DTO')
       !$acc data copyin  (mg_liq_props,icwmrst_grid(:ngrdcol,k), rho_grid(:ngrdcol,k)) &
       !$acc      copy    (ncic_grid(:ngrdcol,k)) &
       !$acc      copyout (mu_grid(:ngrdcol,k),lambdac_grid(:ngrdcol,k))
-      call t_stopf('micro_pumas_cam_tend:H2D')
-      call t_startf('micro_pumas_cam_tend:GPU')
+      call t_stopf('micro_pumas_cam_tend:DTO')
+      call t_startf('micro_pumas_cam_tend:ACCR')
       call size_dist_param_liq(mg_liq_props, icwmrst_grid(:ngrdcol,k), &
            ncic_grid(:ngrdcol,k), rho_grid(:ngrdcol,k), &
            mu_grid(:ngrdcol,k), lambdac_grid(:ngrdcol,k), ngrdcol)
-      call t_stopf('micro_pumas_cam_tend:GPU')
-      call t_startf('micro_pumas_cam_tend:D2H')
+      call t_stopf('micro_pumas_cam_tend:ACCR')
+      call t_startf('micro_pumas_cam_tend:DTO')
       !$acc end data
-      call t_stopf('micro_pumas_cam_tend:D2H')
+      call t_stopf('micro_pumas_cam_tend:DTO')
    end do
-   call t_startf('micro_pumas_cam_tend:CPU')
+   call t_startf('micro_pumas_cam_tend:NAR')
 
    where (icwmrst_grid(:ngrdcol,top_lev:) >= qsmall)
       rel_grid(:ngrdcol,top_lev:) = &
@@ -2976,23 +2976,23 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
 
    niic_grid(:ngrdcol,top_lev:) = ni_grid(:ngrdcol,top_lev:) / &
         max(mincld,icecldf_grid(:ngrdcol,top_lev:))
-   call t_stopf('micro_pumas_cam_tend:CPU')
+   call t_stopf('micro_pumas_cam_tend:NAR')
 
    do k = top_lev, pver
-      call t_startf('micro_pumas_cam_tend:H2D')
+      call t_startf('micro_pumas_cam_tend:DTO')
       !$acc data copyin  (mg_ice_props, icimrst_grid(:ngrdcol,k)) &
       !$acc      copy    (niic_grid(:ngrdcol,k)) &
       !$acc      copyout (rei_grid(:ngrdcol,k))
-      call t_stopf('micro_pumas_cam_tend:H2D')
-      call t_startf('micro_pumas_cam_tend:GPU')
+      call t_stopf('micro_pumas_cam_tend:DTO')
+      call t_startf('micro_pumas_cam_tend:ACCR')
       call size_dist_param_basic(mg_ice_props,icimrst_grid(:ngrdcol,k), &
                                  niic_grid(:ngrdcol,k),rei_grid(:ngrdcol,k),ngrdcol)
-      call t_stopf('micro_pumas_cam_tend:GPU')
-      call t_startf('micro_pumas_cam_tend:D2H')
+      call t_stopf('micro_pumas_cam_tend:ACCR')
+      call t_startf('micro_pumas_cam_tend:DTO')
       !$acc end data
-      call t_stopf('micro_pumas_cam_tend:D2H')
+      call t_stopf('micro_pumas_cam_tend:DTO')
    end do
-   call t_startf('micro_pumas_cam_tend:CPU')
+   call t_startf('micro_pumas_cam_tend:NAR')
 
    where (icimrst_grid(:ngrdcol,top_lev:) >= qsmall)
       rei_grid(:ngrdcol,top_lev:) = 1.5_r8/rei_grid(:ngrdcol,top_lev:) &
@@ -3542,7 +3542,7 @@ subroutine micro_pumas_cam_tend(state, ptend, dtime, pbuf)
    if (qsatfac_idx <= 0) then
       deallocate(qsatfac)
    end if
-   call t_stopf('micro_pumas_cam_tend:CPU')
+   call t_stopf('micro_pumas_cam_tend:NAR')
 
 end subroutine micro_pumas_cam_tend
 

--- a/src/physics/cam_dev/physpkg.F90
+++ b/src/physics/cam_dev/physpkg.F90
@@ -27,7 +27,7 @@ module physpkg
   use phys_control,     only: phys_do_flux_avg, phys_getopts, waccmx_is
   use scamMod,          only: single_column, scm_crm_mode
   use flux_avg,         only: flux_avg_init
-  use perf_mod
+  use perf_mod,         only: t_startf, t_stopf
   use cam_logfile,     only: iulog
   use camsrfexch,      only: cam_export
 
@@ -1374,7 +1374,7 @@ contains
     use charge_neutrality,  only: charge_balance
     use qbo,                only: qbo_relax
     use iondrag,            only: iondrag_calc, do_waccm_ions
-    use perf_mod
+    use perf_mod,           only: t_startf,t_stopf
     use flux_avg,           only: flux_avg_run
     use cam_history,        only: hist_fld_active, outfld
     use qneg_module,        only: qneg4
@@ -2512,7 +2512,7 @@ contains
     use check_energy,    only: tot_energy_phys
     use dycore,          only: dycore_is
     use radiation,       only: radiation_tend
-    use perf_mod
+    use perf_mod,        only: t_startf, t_stopf
     use mo_gas_phase_chemdr,only: map2chm
     use clybry_fam,         only: clybry_fam_adj
     use cam_abortutils,  only: endrun
@@ -2921,7 +2921,7 @@ subroutine phys_timestep_init(phys_state, cam_in, cam_out, pbuf2d)
   use solar_data,          only: solar_data_advance
   use qbo,                 only: qbo_timestep_init
   use iondrag,             only: do_waccm_ions, iondrag_timestep_init
-  use perf_mod
+  use perf_mod             only: t_startf, t_stopf
 
   use prescribed_ozone,    only: prescribed_ozone_adv
   use prescribed_ghg,      only: prescribed_ghg_adv

--- a/src/physics/rrtmgp/radiation.F90
+++ b/src/physics/rrtmgp/radiation.F90
@@ -58,6 +58,7 @@ use mo_fluxes_byband,      only: ty_fluxes_byband
 use string_utils,        only: to_lower
 use cam_abortutils,      only: endrun, handle_allocate_error
 use cam_logfile,         only: iulog
+use perf_mod
 
 
 implicit none
@@ -1110,6 +1111,7 @@ subroutine radiation_tend( &
 
       if (dosw) then
 
+         call t_startf('radiation_tend:CPU:cloud_sw')
          ! Set cloud optical properties in cloud_sw object.
          call rrtmgp_set_cloud_sw( &
             state, pbuf, nlay, nday, idxday,                              &
@@ -1118,6 +1120,7 @@ subroutine radiation_tend( &
             rd%tot_cld_vistau, rd%tot_icld_vistau, rd%liq_icld_vistau,    &
             rd%ice_icld_vistau, rd%snow_icld_vistau, rd%grau_icld_vistau, &
             cld_tau_cloudsim, snow_tau_cloudsim, grau_tau_cloudsim )
+         call t_stopf('radiation_tend:CPU:cloud_sw')
 
          if (write_output) then
             call radiation_output_cld(lchnk, rd)
@@ -1148,20 +1151,28 @@ subroutine radiation_tend( &
 
                if (nday > 0) then
 
+                  call t_startf('radiation_tend:CPU:gases_sw')
                   ! Set gas volume mixing ratios for this call in gas_concs_sw.
                   call rrtmgp_set_gases_sw( &
                      icall, state, pbuf, nlay, nday, &
                      idxday, gas_concs_sw)
+                  call t_stopf('radiation_tend:CPU:gases_sw')
 
                   ! Compute the gas optics (stored in atm_optics_sw).
                   ! toa_flux is the reference solar source from RRTMGP data.
+                  call t_startf('radiation_tend:H2D')
                   !$acc data copyin(kdist_sw,pmid_day,pint_day,t_day,gas_concs_sw) &
                   !$acc      copy(atm_optics_sw) &
                   !$acc      copyout(toa_flux)
+                  call t_stopf('radiation_tend:H2D')
+                  call t_startf('radiation_tend:GPU')
                   errmsg = kdist_sw%gas_optics( &
                      pmid_day, pint_day, t_day, gas_concs_sw, atm_optics_sw, &
                      toa_flux)
+                  call t_stopf('radiation_tend:GPU')
+                  call t_startf('radiation_tend:D2H')
                   !$acc end data
+                  call t_stopf('radiation_tend:D2H')
                   call stop_on_err(errmsg, sub, 'kdist_sw%gas_optics')
 
                   ! Scale the solar source
@@ -1173,12 +1184,15 @@ subroutine radiation_tend( &
                ! Set SW aerosol optical properties in the aer_sw object.
                ! This call made even when no daylight columns because it does some
                ! diagnostic aerosol output.
+               call t_startf('radiation_tend:CPU:aer_sw')
                call rrtmgp_set_aer_sw( &
                   icall, state, pbuf, nday, idxday, nnite, idxnite, aer_sw)
+               call t_stopf('radiation_tend:CPU:aer_sw')
                   
                if (nday > 0) then
 
                   !! ADDED by SS as part of RRTMGP data optimization
+                  call t_startf('radiation_tend:H2D')
                   !$acc data copyin(atm_optics_sw, toa_flux, &
                   !$acc aer_sw, cloud_sw,  &
                   !$acc aer_sw%tau, aer_sw%ssa, aer_sw%g, &
@@ -1188,6 +1202,8 @@ subroutine radiation_tend( &
                   !$acc alb_dir, alb_dif,coszrs_day) &
                   !$acc copy(fswc, fswc%flux_net,fswc%flux_up,fswc%flux_dn, &
                   !$acc      fsw,   fsw%flux_net, fsw%flux_up, fsw%flux_dn)
+                  call t_stopf('radiation_tend:H2D')
+                  call t_startf('radiation_tend:GPU')
 
                   ! Increment the gas optics (in atm_optics_sw) by the aerosol optics in aer_sw.
                   errmsg = aer_sw%increment(atm_optics_sw)
@@ -1208,7 +1224,10 @@ subroutine radiation_tend( &
                      atm_optics_sw, top_at_1, coszrs_day, toa_flux, &
                      alb_dir, alb_dif, fsw)
                   call stop_on_err(errmsg, sub, 'all-sky rte_sw')
+                  call t_stopf('radiation_tend:GPU')
+                  call t_startf('radiation_tend:D2H')
                   !$acc end data
+                  call t_stopf('radiation_tend:D2H')
 
                end if
 
@@ -1239,10 +1258,12 @@ subroutine radiation_tend( &
          call stop_on_err(errmsg, sub, 'sources_lw%alloc')
 
          ! Set cloud optical properties in cloud_lw object.
+         call t_startf('radiation_tend:CPU:cloud_lw')
          call rrtmgp_set_cloud_lw( &
             state, pbuf, ncol, nlay, nlaycam, &
             cld, cldfsnow, cldfgrau, cldfprime, graupel_in_rad, &
             kdist_lw, cloud_lw, cld_lw_abs_cloudsim, snow_lw_abs_cloudsim, grau_lw_abs_cloudsim)
+         call t_stopf('radiation_tend:CPU:cloud_lw')
 
          ! Initialize object for gas concentrations
          errmsg = gas_concs_lw%init(gaslist_lc)
@@ -1261,10 +1282,13 @@ subroutine radiation_tend( &
 
             if (active_calls(icall)) then
 
+               call t_startf('radiation_tend:CPU:gases_lw')
                ! Set gas volume mixing ratios for this call in gas_concs_lw.
                call rrtmgp_set_gases_lw(icall, state, pbuf, nlay, gas_concs_lw)
+               call t_stopf('radiation_tend:CPU:gases_lw')
 
                ! Compute the gas optics and Planck sources.
+               call t_startf('radiation_tend:H2D')
                !$acc data copyin(kdist_lw,pmid_rad,pint_rad,t_rad,t_sfc, &
                !$acc gas_concs_lw) &
                !$acc copy(atm_optics_lw, &
@@ -1272,16 +1296,24 @@ subroutine radiation_tend( &
                !$acc sources_lw%lay_source, sources_lw%sfc_source,  &
                !$acc sources_lw%lev_source_inc, sources_lw%lev_source_dec, &
                !$acc sources_lw%sfc_source_jac)
+               call t_stopf('radiation_tend:H2D')
+               call t_startf('radiation_tend:GPU')
                errmsg = kdist_lw%gas_optics( &
                   pmid_rad, pint_rad, t_rad, t_sfc, gas_concs_lw, &
                   atm_optics_lw, sources_lw)
                call stop_on_err(errmsg, sub, 'kdist_lw%gas_optics')
+               call t_stopf('radiation_tend:GPU')
+               call t_startf('radiation_tend:D2H')
                !$acc end data
+               call t_stopf('radiation_tend:D2H')
 
                ! Set LW aerosol optical properties in the aer_lw object.
+               call t_startf('radiation_tend:CPU:aer_lw')
                call rrtmgp_set_aer_lw(icall, state, pbuf, aer_lw)
+               call t_stopf('radiation_tend:CPU:aer_lw')
                
                !! Added by SS as part of RRTMGP data optimization
+               call t_startf('radiation_tend:H2D')
                !$acc data copyin(atm_optics_lw, aer_lw, cloud_lw,  &
                !$acc aer_lw%tau, &
                !$acc atm_optics_lw%tau, &
@@ -1293,7 +1325,8 @@ subroutine radiation_tend( &
                !$acc emis_sfc)  &
                !$acc copy(flwc, flwc%flux_net,flwc%flux_up,flwc%flux_dn, &
                !$acc      flw,   flw%flux_net, flw%flux_up, flw%flux_dn)
-
+               call t_stopf('radiation_tend:H2D')
+               call t_startf('radiation_tend:GPU')
 
                ! Increment the gas optics by the aerosol optics.
                errmsg = aer_lw%increment(atm_optics_lw)
@@ -1310,7 +1343,10 @@ subroutine radiation_tend( &
                ! Compute all-sky LW fluxes
                errmsg = rte_lw(atm_optics_lw, top_at_1, sources_lw, emis_sfc, flw)
                call stop_on_err(errmsg, sub, 'all-sky rte_lw')
+               call t_stopf('radiation_tend:GPU')
+               call t_startf('radiation_tend:D2H')
                !$acc end data
+               call t_stopf('radiation_tend:D2H')
 
                ! Transform RRTMGP outputs to CAM outputs and compute heating rates.
                call set_lw_diags()
@@ -1338,6 +1374,7 @@ subroutine radiation_tend( &
 
       if (docosp) then
 
+         call t_startf('radiation_tend:CPU:cosp')
          emis(:,:) = 0._r8
          emis(:ncol,:) = 1._r8 - exp(-cld_lw_abs_cloudsim(:ncol,:))
          call outfld('EMIS', emis, pcols, lchnk)
@@ -1379,6 +1416,7 @@ subroutine radiation_tend( &
                snow_emis_in=gb_snow_lw)
             cosp_cnt(lchnk) = 0
          end if
+         call t_stopf('radiation_tend:CPU:cosp')
       end if   ! docosp
       
    else

--- a/src/physics/rrtmgp/radiation.F90
+++ b/src/physics/rrtmgp/radiation.F90
@@ -58,7 +58,7 @@ use mo_fluxes_byband,      only: ty_fluxes_byband
 use string_utils,        only: to_lower
 use cam_abortutils,      only: endrun, handle_allocate_error
 use cam_logfile,         only: iulog
-use perf_mod
+use perf_mod,            only: t_startf, t_stopf
 
 
 implicit none

--- a/src/physics/rrtmgp/radiation.F90
+++ b/src/physics/rrtmgp/radiation.F90
@@ -1111,7 +1111,7 @@ subroutine radiation_tend( &
 
       if (dosw) then
 
-         call t_startf('radiation_tend:CPU:cloud_sw')
+         call t_startf('radiation_tend:NAR:cloud_sw')
          ! Set cloud optical properties in cloud_sw object.
          call rrtmgp_set_cloud_sw( &
             state, pbuf, nlay, nday, idxday,                              &
@@ -1120,7 +1120,7 @@ subroutine radiation_tend( &
             rd%tot_cld_vistau, rd%tot_icld_vistau, rd%liq_icld_vistau,    &
             rd%ice_icld_vistau, rd%snow_icld_vistau, rd%grau_icld_vistau, &
             cld_tau_cloudsim, snow_tau_cloudsim, grau_tau_cloudsim )
-         call t_stopf('radiation_tend:CPU:cloud_sw')
+         call t_stopf('radiation_tend:NAR:cloud_sw')
 
          if (write_output) then
             call radiation_output_cld(lchnk, rd)
@@ -1151,28 +1151,28 @@ subroutine radiation_tend( &
 
                if (nday > 0) then
 
-                  call t_startf('radiation_tend:CPU:gases_sw')
+                  call t_startf('radiation_tend:NAR:gases_sw')
                   ! Set gas volume mixing ratios for this call in gas_concs_sw.
                   call rrtmgp_set_gases_sw( &
                      icall, state, pbuf, nlay, nday, &
                      idxday, gas_concs_sw)
-                  call t_stopf('radiation_tend:CPU:gases_sw')
+                  call t_stopf('radiation_tend:NAR:gases_sw')
 
                   ! Compute the gas optics (stored in atm_optics_sw).
                   ! toa_flux is the reference solar source from RRTMGP data.
-                  call t_startf('radiation_tend:H2D')
+                  call t_startf('radiation_tend:DTO')
                   !$acc data copyin(kdist_sw,pmid_day,pint_day,t_day,gas_concs_sw) &
                   !$acc      copy(atm_optics_sw) &
                   !$acc      copyout(toa_flux)
-                  call t_stopf('radiation_tend:H2D')
-                  call t_startf('radiation_tend:GPU')
+                  call t_stopf('radiation_tend:DTO')
+                  call t_startf('radiation_tend:ACCR')
                   errmsg = kdist_sw%gas_optics( &
                      pmid_day, pint_day, t_day, gas_concs_sw, atm_optics_sw, &
                      toa_flux)
-                  call t_stopf('radiation_tend:GPU')
-                  call t_startf('radiation_tend:D2H')
+                  call t_stopf('radiation_tend:ACCR')
+                  call t_startf('radiation_tend:DTO')
                   !$acc end data
-                  call t_stopf('radiation_tend:D2H')
+                  call t_stopf('radiation_tend:DTO')
                   call stop_on_err(errmsg, sub, 'kdist_sw%gas_optics')
 
                   ! Scale the solar source
@@ -1184,15 +1184,15 @@ subroutine radiation_tend( &
                ! Set SW aerosol optical properties in the aer_sw object.
                ! This call made even when no daylight columns because it does some
                ! diagnostic aerosol output.
-               call t_startf('radiation_tend:CPU:aer_sw')
+               call t_startf('radiation_tend:NAR:aer_sw')
                call rrtmgp_set_aer_sw( &
                   icall, state, pbuf, nday, idxday, nnite, idxnite, aer_sw)
-               call t_stopf('radiation_tend:CPU:aer_sw')
+               call t_stopf('radiation_tend:NAR:aer_sw')
                   
                if (nday > 0) then
 
                   !! ADDED by SS as part of RRTMGP data optimization
-                  call t_startf('radiation_tend:H2D')
+                  call t_startf('radiation_tend:DTO')
                   !$acc data copyin(atm_optics_sw, toa_flux, &
                   !$acc aer_sw, cloud_sw,  &
                   !$acc aer_sw%tau, aer_sw%ssa, aer_sw%g, &
@@ -1202,8 +1202,8 @@ subroutine radiation_tend( &
                   !$acc alb_dir, alb_dif,coszrs_day) &
                   !$acc copy(fswc, fswc%flux_net,fswc%flux_up,fswc%flux_dn, &
                   !$acc      fsw,   fsw%flux_net, fsw%flux_up, fsw%flux_dn)
-                  call t_stopf('radiation_tend:H2D')
-                  call t_startf('radiation_tend:GPU')
+                  call t_stopf('radiation_tend:DTO')
+                  call t_startf('radiation_tend:ACCR')
 
                   ! Increment the gas optics (in atm_optics_sw) by the aerosol optics in aer_sw.
                   errmsg = aer_sw%increment(atm_optics_sw)
@@ -1224,10 +1224,10 @@ subroutine radiation_tend( &
                      atm_optics_sw, top_at_1, coszrs_day, toa_flux, &
                      alb_dir, alb_dif, fsw)
                   call stop_on_err(errmsg, sub, 'all-sky rte_sw')
-                  call t_stopf('radiation_tend:GPU')
-                  call t_startf('radiation_tend:D2H')
+                  call t_stopf('radiation_tend:ACCR')
+                  call t_startf('radiation_tend:DTO')
                   !$acc end data
-                  call t_stopf('radiation_tend:D2H')
+                  call t_stopf('radiation_tend:DTO')
 
                end if
 
@@ -1258,12 +1258,12 @@ subroutine radiation_tend( &
          call stop_on_err(errmsg, sub, 'sources_lw%alloc')
 
          ! Set cloud optical properties in cloud_lw object.
-         call t_startf('radiation_tend:CPU:cloud_lw')
+         call t_startf('radiation_tend:NAR:cloud_lw')
          call rrtmgp_set_cloud_lw( &
             state, pbuf, ncol, nlay, nlaycam, &
             cld, cldfsnow, cldfgrau, cldfprime, graupel_in_rad, &
             kdist_lw, cloud_lw, cld_lw_abs_cloudsim, snow_lw_abs_cloudsim, grau_lw_abs_cloudsim)
-         call t_stopf('radiation_tend:CPU:cloud_lw')
+         call t_stopf('radiation_tend:NAR:cloud_lw')
 
          ! Initialize object for gas concentrations
          errmsg = gas_concs_lw%init(gaslist_lc)
@@ -1282,13 +1282,13 @@ subroutine radiation_tend( &
 
             if (active_calls(icall)) then
 
-               call t_startf('radiation_tend:CPU:gases_lw')
+               call t_startf('radiation_tend:NAR:gases_lw')
                ! Set gas volume mixing ratios for this call in gas_concs_lw.
                call rrtmgp_set_gases_lw(icall, state, pbuf, nlay, gas_concs_lw)
-               call t_stopf('radiation_tend:CPU:gases_lw')
+               call t_stopf('radiation_tend:NAR:gases_lw')
 
                ! Compute the gas optics and Planck sources.
-               call t_startf('radiation_tend:H2D')
+               call t_startf('radiation_tend:DTO')
                !$acc data copyin(kdist_lw,pmid_rad,pint_rad,t_rad,t_sfc, &
                !$acc gas_concs_lw) &
                !$acc copy(atm_optics_lw, &
@@ -1296,24 +1296,24 @@ subroutine radiation_tend( &
                !$acc sources_lw%lay_source, sources_lw%sfc_source,  &
                !$acc sources_lw%lev_source_inc, sources_lw%lev_source_dec, &
                !$acc sources_lw%sfc_source_jac)
-               call t_stopf('radiation_tend:H2D')
-               call t_startf('radiation_tend:GPU')
+               call t_stopf('radiation_tend:DTO')
+               call t_startf('radiation_tend:ACCR')
                errmsg = kdist_lw%gas_optics( &
                   pmid_rad, pint_rad, t_rad, t_sfc, gas_concs_lw, &
                   atm_optics_lw, sources_lw)
                call stop_on_err(errmsg, sub, 'kdist_lw%gas_optics')
-               call t_stopf('radiation_tend:GPU')
-               call t_startf('radiation_tend:D2H')
+               call t_stopf('radiation_tend:ACCR')
+               call t_startf('radiation_tend:DTO')
                !$acc end data
-               call t_stopf('radiation_tend:D2H')
+               call t_stopf('radiation_tend:DTO')
 
                ! Set LW aerosol optical properties in the aer_lw object.
-               call t_startf('radiation_tend:CPU:aer_lw')
+               call t_startf('radiation_tend:NAR:aer_lw')
                call rrtmgp_set_aer_lw(icall, state, pbuf, aer_lw)
-               call t_stopf('radiation_tend:CPU:aer_lw')
+               call t_stopf('radiation_tend:NAR:aer_lw')
                
                !! Added by SS as part of RRTMGP data optimization
-               call t_startf('radiation_tend:H2D')
+               call t_startf('radiation_tend:DTO')
                !$acc data copyin(atm_optics_lw, aer_lw, cloud_lw,  &
                !$acc aer_lw%tau, &
                !$acc atm_optics_lw%tau, &
@@ -1325,8 +1325,8 @@ subroutine radiation_tend( &
                !$acc emis_sfc)  &
                !$acc copy(flwc, flwc%flux_net,flwc%flux_up,flwc%flux_dn, &
                !$acc      flw,   flw%flux_net, flw%flux_up, flw%flux_dn)
-               call t_stopf('radiation_tend:H2D')
-               call t_startf('radiation_tend:GPU')
+               call t_stopf('radiation_tend:DTO')
+               call t_startf('radiation_tend:ACCR')
 
                ! Increment the gas optics by the aerosol optics.
                errmsg = aer_lw%increment(atm_optics_lw)
@@ -1343,10 +1343,10 @@ subroutine radiation_tend( &
                ! Compute all-sky LW fluxes
                errmsg = rte_lw(atm_optics_lw, top_at_1, sources_lw, emis_sfc, flw)
                call stop_on_err(errmsg, sub, 'all-sky rte_lw')
-               call t_stopf('radiation_tend:GPU')
-               call t_startf('radiation_tend:D2H')
+               call t_stopf('radiation_tend:ACCR')
+               call t_startf('radiation_tend:DTO')
                !$acc end data
-               call t_stopf('radiation_tend:D2H')
+               call t_stopf('radiation_tend:DTO')
 
                ! Transform RRTMGP outputs to CAM outputs and compute heating rates.
                call set_lw_diags()
@@ -1374,7 +1374,7 @@ subroutine radiation_tend( &
 
       if (docosp) then
 
-         call t_startf('radiation_tend:CPU:cosp')
+         call t_startf('radiation_tend:NAR:cosp')
          emis(:,:) = 0._r8
          emis(:ncol,:) = 1._r8 - exp(-cld_lw_abs_cloudsim(:ncol,:))
          call outfld('EMIS', emis, pcols, lchnk)
@@ -1416,7 +1416,7 @@ subroutine radiation_tend( &
                snow_emis_in=gb_snow_lw)
             cosp_cnt(lchnk) = 0
          end if
-         call t_stopf('radiation_tend:CPU:cosp')
+         call t_stopf('radiation_tend:NAR:cosp')
       end if   ! docosp
       
    else


### PR DESCRIPTION
This PR adds more detailed timers to CAM to help identify which areas of CAM have been GPU-enabled.  These changes can be grouped into two different types:

    (1). Change the name of the timer to better indicate the subroutine that is called.  For example, the timer 'adv_tracer_src_snk' was replaced by the new name 'chem_timestep_tend'

   (2). Additional detail was encoded into some of the timers' names to indicate whether it was executed on the CPU or GPU.

  (3) Host-to-device and device-to-host data movement was also indicated through the use of the H2D or D2H strings  