### PR TITLE
Fix loop bounds in EWOrg/MPAS-Model for DEBUG=true runs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -91,10 +91,12 @@
 
 [submodule "mpas"]
 	path = src/dynamics/mpas/dycore
-	url = https://github.com/EarthWorksOrg/MPAS-Model.git
+	# url = https://github.com/EarthWorksOrg/MPAS-Model.git
+	url = https://github.com/gdicker1/MPAS-Model.git
         fxrequired = AlwaysRequired
         fxsparse = ../.mpas_sparse_checkout
-        fxtag = release-mpasa-ew2.4
+        # fxtag = release-mpasa-ew2.4
+        fxtag = fix/gpu_tend_physics_loopbounds
 	fxDONOTUSEurl = https://github.com/MPAS-Dev/MPAS-Model.git
 
 [submodule "cosp2"]


### PR DESCRIPTION
Fixes loop bounds that cause CAM-MPAS runs in EarthWorks to fail if built with DEBUG=true. This applies to CPU and GPU runs.