### PR TITLE
Better align with upstream tag cam6_4_048

### DIFF
--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -3440,10 +3440,11 @@
 <mpas_time_integration        > SRK3 </mpas_time_integration>
 <mpas_time_integration_order  > 2 </mpas_time_integration_order>
 <mpas_dt                      > 1800.0D0 </mpas_dt>
-<mpas_dt hgrid="mpasa120"     >  600.0D0 </mpas_dt>
+<mpas_dt hgrid="mpasa120"     >  900.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa120" waccm_phys="1"> 600.D0 </mpas_dt>
-<mpas_dt hgrid="mpasa60"      >  300.0D0 </mpas_dt>
-<mpas_dt hgrid="mpasa30"      >  150.0D0 </mpas_dt>
+<mpas_dt hgrid="mpasa60"      >  450.0D0 </mpas_dt>
+<mpas_dt hgrid="mpasa30"      >  225.0D0 </mpas_dt>
+<!-- These values correlate to 3 MPAS timesteps per CAM step -->
 <mpas_dt hgrid="mpasa15"      >   80.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa7p5"     >   40.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa3p75"    >   20.0D0 </mpas_dt>

--- a/src/dynamics/mpas/dyn_comp.F90
+++ b/src/dynamics/mpas/dyn_comp.F90
@@ -686,11 +686,7 @@ subroutine dyn_final(dyn_in, dyn_out)
    nullify(dyn_in % theta_m)
    nullify(dyn_in % rho_zz)
    nullify(dyn_in % tracers)
-   !SS: This a work around for the deallocation bug
-   !deallocate(dyn_in % mpas_from_cam_cnst)
-   if (associated(dyn_in % mpas_from_cam_cnst)) then
-     nullify(dyn_in % mpas_from_cam_cnst)
-   endif
+   deallocate(dyn_in % mpas_from_cam_cnst)
    nullify(dyn_in % rho_base)
    nullify(dyn_in % theta_base)
    dyn_in % index_qv = 0
@@ -726,11 +722,7 @@ subroutine dyn_final(dyn_in, dyn_out)
    nullify(dyn_out % theta_m)
    nullify(dyn_out % rho_zz)
    nullify(dyn_out % tracers)
-   !SS: This a work around for the deallocation bug
-   !deallocate(dyn_out % cam_from_mpas_cnst)
-   if (associated(dyn_out % cam_from_mpas_cnst)) then
-     nullify(dyn_out % cam_from_mpas_cnst)
-   endif
+   deallocate(dyn_out % cam_from_mpas_cnst)
    dyn_out % index_qv = 0
    nullify(dyn_out % zint)
    nullify(dyn_out % zz)

--- a/src/physics/cam/aerosol_optics_cam.F90
+++ b/src/physics/cam/aerosol_optics_cam.F90
@@ -1,5 +1,3 @@
-#define _881FIX_
-#define _945FIX_
 module aerosol_optics_cam
   use shr_kind_mod, only: r8 => shr_kind_r8
   use shr_kind_mod, only: cl => shr_kind_cl
@@ -38,21 +36,12 @@ module aerosol_optics_cam
   public :: aerosol_optics_cam_sw
   public :: aerosol_optics_cam_lw
 
-#ifdef _945FIX_
-  type aero_props_t
-      type(modal_aerosol_properties), pointer :: obj => null()
-  end type aero_props_t
-  type aero_state_t
-      type(modal_aerosol_state), pointer :: obj => null()
-  end type aero_state_t
-#else
   type aero_props_t
      class(aerosol_properties), pointer :: obj => null()
   end type aero_props_t
   type aero_state_t
      class(aerosol_state), pointer :: obj => null()
   end type aero_state_t
-#endif
 
   type(aero_props_t), allocatable :: aero_props(:) ! array of aerosol properties objects to allow for
                                                    ! multiple aerosol representations in the same sim
@@ -866,63 +855,33 @@ contains
             case('dust')
                dustvol(icol) = vol(icol)
                burdendust(icol) = burdendust(icol) + specmmr(icol,ilev)*mass(icol,ilev)
-#ifdef _881FIX_
-               scatdust(icol) = vol(icol) * DBLE(specrefindex(iwav))
-               absdust(icol)  =-vol(icol) * DIMAG(specrefindex(iwav))
-#else
                scatdust(icol) = vol(icol) * specrefindex(iwav)%re
                absdust(icol)  =-vol(icol) * specrefindex(iwav)%im
-#endif
                hygrodust(icol)= vol(icol)*hygro_aer
             case('black-c')
                burdenbc(icol) = burdenbc(icol) + specmmr(icol,ilev)*mass(icol,ilev)
-#ifdef _881FIX_
-               scatbc(icol) = vol(icol) * DBLE(specrefindex(iwav))
-               absbc(icol)  =-vol(icol) * DIMAG(specrefindex(iwav))
-#else
                scatbc(icol) = vol(icol) * specrefindex(iwav)%re
                absbc(icol)  =-vol(icol) * specrefindex(iwav)%im
-#endif
                hygrobc(icol)= vol(icol)*hygro_aer
             case('sulfate')
                burdenso4(icol) = burdenso4(icol) + specmmr(icol,ilev)*mass(icol,ilev)
-#ifdef _881FIX_
-               scatsulf(icol) = vol(icol) * DBLE(specrefindex(iwav))
-               abssulf(icol)  =-vol(icol) * DIMAG(specrefindex(iwav))
-#else
                scatsulf(icol) = vol(icol) * specrefindex(iwav)%re
                abssulf(icol)  =-vol(icol) * specrefindex(iwav)%im
-#endif
                hygrosulf(icol)= vol(icol)*hygro_aer
             case('p-organic')
                burdenpom(icol) = burdenpom(icol) + specmmr(icol,ilev)*mass(icol,ilev)
-#ifdef _881FIX_
-               scatpom(icol) = vol(icol) * DBLE(specrefindex(iwav))
-               abspom(icol)  =-vol(icol) * DIMAG(specrefindex(iwav))
-#else
                scatpom(icol) = vol(icol) * specrefindex(iwav)%re
                abspom(icol)  =-vol(icol) * specrefindex(iwav)%im
-#endif
                hygropom(icol)= vol(icol)*hygro_aer
             case('s-organic')
                burdensoa(icol) = burdensoa(icol) + specmmr(icol,ilev)*mass(icol,ilev)
-#ifdef _881FIX_
-               scatsoa(icol) = vol(icol) * DBLE(specrefindex(iwav))
-               abssoa(icol)  =-vol(icol) * DIMAG(specrefindex(iwav))
-#else
                scatsoa(icol) = vol(icol) * specrefindex(iwav)%re
                abssoa(icol) = -vol(icol) * specrefindex(iwav)%im
-#endif
                hygrosoa(icol)= vol(icol)*hygro_aer
             case('seasalt')
                burdenseasalt(icol) = burdenseasalt(icol) + specmmr(icol,ilev)*mass(icol,ilev)
-#ifdef _881FIX_
-               scatsslt(icol) = vol(icol) * DBLE(specrefindex(iwav))
-               abssslt(icol)  =-vol(icol) * DIMAG(specrefindex(iwav))
-#else
                scatsslt(icol) = vol(icol) * specrefindex(iwav)%re
                abssslt(icol) = -vol(icol) * specrefindex(iwav)%im
-#endif
                hygrosslt(icol)= vol(icol)*hygro_aer
             end select
          end do
@@ -934,13 +893,8 @@ contains
             ! partition optical depth into contributions from each constituent
             ! assume contribution is proportional to refractive index X volume
 
-#ifdef _881FIX_
-            scath2o = watervol(icol,ilev)*DBLE(crefwsw(iwav))
-            absh2o = -watervol(icol,ilev)*DIMAG(crefwsw(iwav))
-#else
             scath2o = watervol(icol,ilev)*crefwsw(iwav)%re
             absh2o = -watervol(icol,ilev)*crefwsw(iwav)%im
-#endif
             sumscat = scatsulf(icol) + scatpom(icol) + scatsoa(icol) + scatbc(icol) + &
                  scatdust(icol) + scatsslt(icol) + scath2o
             sumabs  = abssulf(icol) + abspom(icol) + abssoa(icol) + absbc(icol) + &

--- a/src/physics/rrtmgp/radiation.F90
+++ b/src/physics/rrtmgp/radiation.F90
@@ -1171,22 +1171,13 @@ subroutine radiation_tend( &
                      idxday, gas_concs_sw)
                   call t_stopf('radiation_tend:NAR:gases_sw')
 
-                  call t_startf('radiation_tend:DTO')
                   ! Compute the gas optics (stored in atm_optics_sw).
                   ! toa_flux is the reference solar source from RRTMGP data.
-                  !$acc data copyin(kdist_sw,pmid_day,pint_day,t_day,gas_concs_sw) &
-                  !$acc      copy(atm_optics_sw) &
-                  !$acc      copyout(toa_flux)
-                  call t_stopf('radiation_tend:DTO')
-
                   call t_startf('radiation_tend:ACCR')
                   errmsg = kdist_sw%gas_optics( &
                      pmid_day, pint_day, t_day, gas_concs_sw, atm_optics_sw, &
                      toa_flux)
                   call t_stopf('radiation_tend:ACCR')
-                  call t_startf('radiation_tend:DTO')
-                  !$acc end data
-                  call t_stopf('radiation_tend:DTO')
                   call stop_on_err(errmsg, sub, 'kdist_sw%gas_optics')
 
                   ! Scale the solar source
@@ -1204,19 +1195,6 @@ subroutine radiation_tend( &
                call t_stopf('radiation_tend:NAR:aer_sw')
                   
                if (nday > 0) then
-
-                  call t_startf('radiation_tend:DTO')
-                  !! ADDED by SS as part of RRTMGP data optimization
-                  !$acc data copyin(atm_optics_sw, toa_flux, &
-                  !$acc aer_sw, cloud_sw,  &
-                  !$acc aer_sw%tau, aer_sw%ssa, aer_sw%g, &
-                  !$acc atm_optics_sw%tau,  &
-                  !$acc atm_optics_sw%ssa, atm_optics_sw%g,   &
-                  !$acc cloud_sw%tau, cloud_sw%ssa, cloud_sw%g,  &
-                  !$acc alb_dir, alb_dif,coszrs_day) &
-                  !$acc copy(fswc, fswc%flux_net,fswc%flux_up,fswc%flux_dn, &
-                  !$acc      fsw,   fsw%flux_net, fsw%flux_up, fsw%flux_dn)
-                  call t_stopf('radiation_tend:DTO')
 
                   call t_startf('radiation_tend:ACCR')
                   ! Increment the gas optics (in atm_optics_sw) by the aerosol optics in aer_sw.
@@ -1239,10 +1217,6 @@ subroutine radiation_tend( &
                      alb_dir, alb_dif, fsw)
                   call stop_on_err(errmsg, sub, 'all-sky rte_sw')
                   call t_stopf('radiation_tend:ACCR')
-
-                  call t_startf('radiation_tend:DTO')
-                  !$acc end data
-                  call t_stopf('radiation_tend:DTO')
 
                end if
 
@@ -1302,17 +1276,7 @@ subroutine radiation_tend( &
                call rrtmgp_set_gases_lw(icall, state, pbuf, nlay, gas_concs_lw)
                call t_stopf('radiation_tend:NAR:gases_lw')
 
-               call t_startf('radiation_tend:DTO')
                ! Compute the gas optics and Planck sources.
-               !$acc data copyin(kdist_lw,pmid_rad,pint_rad,t_rad,t_sfc, &
-               !$acc gas_concs_lw) &
-               !$acc copy(atm_optics_lw, &
-               !$acc atm_optics_lw%tau, sources_lw, &
-               !$acc sources_lw%lay_source, sources_lw%sfc_source,  &
-               !$acc sources_lw%lev_source_inc, sources_lw%lev_source_dec, &
-               !$acc sources_lw%sfc_source_jac)
-               call t_stopf('radiation_tend:DTO')
-
                call t_startf('radiation_tend:ACCR')
                errmsg = kdist_lw%gas_optics( &
                   pmid_rad, pint_rad, t_rad, t_sfc, gas_concs_lw, &
@@ -1320,32 +1284,12 @@ subroutine radiation_tend( &
                call stop_on_err(errmsg, sub, 'kdist_lw%gas_optics')
                call t_stopf('radiation_tend:ACCR')
 
-               call t_startf('radiation_tend:DTO')
-               !$acc end data
-               call t_stopf('radiation_tend:DTO')
-
                ! Set LW aerosol optical properties in the aer_lw object.
                call t_startf('radiation_tend:NAR:aer_lw')
                call rrtmgp_set_aer_lw(icall, state, pbuf, aer_lw)
                call t_stopf('radiation_tend:NAR:aer_lw')
                
-               call t_startf('radiation_tend:DTO')
-               !! Added by SS as part of RRTMGP data optimization
-               !$acc data copyin(atm_optics_lw, aer_lw, cloud_lw,  &
-               !$acc aer_lw%tau, &
-               !$acc atm_optics_lw%tau, &
-               !$acc cloud_lw%tau, &
-               !$acc sources_lw, &
-               !$acc sources_lw%lay_source, sources_lw%sfc_source,  &
-               !$acc sources_lw%lev_source_inc, sources_lw%lev_source_dec,  &
-               !$acc sources_lw%sfc_source_Jac, &
-               !$acc emis_sfc)  &
-               !$acc copy(flwc, flwc%flux_net,flwc%flux_up,flwc%flux_dn, &
-               !$acc      flw,   flw%flux_net, flw%flux_up, flw%flux_dn)
-               call t_stopf('radiation_tend:DTO')
-              call t_startf('radiation_tend:ACCR')
-
-
+               call t_startf('radiation_tend:ACCR')
                ! Increment the gas optics by the aerosol optics.
                errmsg = aer_lw%increment(atm_optics_lw)
                call stop_on_err(errmsg, sub, 'aer_lw%increment')
@@ -1362,10 +1306,6 @@ subroutine radiation_tend( &
                errmsg = rte_lw(atm_optics_lw, top_at_1, sources_lw, emis_sfc, flw)
                call stop_on_err(errmsg, sub, 'all-sky rte_lw')
                call t_stopf('radiation_tend:ACCR')
-
-               call t_startf('radiation_tend:DTO')
-               !$acc end data
-               call t_stopf('radiation_tend:DTO')
 
                ! Transform RRTMGP outputs to CAM outputs and compute heating rates.
                call set_lw_diags()


### PR DESCRIPTION
This PR removes changes introduced in other EarthWorksOrg/CAM PRs including:

- PR#8 dyn_in % mpas_from_cam_cnst deallocation bug fix
- PR#12 Push EWOrg/CAM to cam6_3_145 and patch aerosol_optics_cam.F90
- PR#17 Update EW mpas-a time steps and set radiation intervals (*)
    - Resolutions below mpasa30 now use 2 MPAS-A steps per ATM step just as in ESCOMP/CAM. The mpasa15, mpasa7p5, and mpasa3p75 continue to use 3 MPAS-A steps.
- PR#24 RRTMGP data transfer optimization
- PR#25 Eliminated additional data movement in RRTMGP
