### PR TITLE
Update MPAS-A with a fix for OpenMPI v5.x runs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -91,10 +91,12 @@
 
 [submodule "mpas"]
 	path = src/dynamics/mpas/dycore
-	url = https://github.com/EarthWorksOrg/MPAS-Model.git
+	# url = https://github.com/EarthWorksOrg/MPAS-Model.git
+	url = https://github.com/gdicker1/MPAS-Model.git
         fxrequired = AlwaysRequired
         fxsparse = ../.mpas_sparse_checkout
-        fxtag = mpasa-ew2.4.001
+        # fxtag = mpasa-ew2.4.001
+        fxtag = framework/block_decomp_openmpi_v5x
 	fxDONOTUSEurl = https://github.com/MPAS-Dev/MPAS-Model.git
 
 [submodule "cosp2"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -91,12 +91,10 @@
 
 [submodule "mpas"]
 	path = src/dynamics/mpas/dycore
-	# url = https://github.com/EarthWorksOrg/MPAS-Model.git
-	url = https://github.com/gdicker1/MPAS-Model.git
+	url = https://github.com/EarthWorksOrg/MPAS-Model.git
         fxrequired = AlwaysRequired
         fxsparse = ../.mpas_sparse_checkout
-        # fxtag = mpasa-ew2.4.001
-        fxtag = framework/block_decomp_openmpi_v5x
+        fxtag = mpasa-ew2.4.002
 	fxDONOTUSEurl = https://github.com/MPAS-Dev/MPAS-Model.git
 
 [submodule "cosp2"]


### PR DESCRIPTION
This incorporates changes in MPAS-A to workaround run time fails that could occur with OpenMPI v5.x during initialization. An interaction with MPI_ScatterV and repeated reads of a block decomp file seems to be responsible.