### PR TITLE
Fix some of memory leaked by NVHPC v24.9+

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,8 +36,7 @@
 [submodule "atmos_phys"]
 	path = src/atmos_phys
 	url = https://github.com/EarthWorksOrg/atmospheric_physics
-        # fxtag = atmos_phys-ew2.5.000
-        fxtag = fix/nvhpc_mem_leak_01
+        fxtag = atmos_phys-ew2.5.001
         fxrequired = AlwaysRequired
 	fxDONOTUSEurl = https://github.com/ESCOMP/atmospheric_physics
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -35,8 +35,8 @@
 
 [submodule "atmos_phys"]
 	path = src/atmos_phys
-	url = https://github.com/ESCOMP/atmospheric_physics
-        fxtag = atmos_phys0_13_000
+	url = https://github.com/EarthWorksOrg/atmospheric_physics
+        fxtag = atmos_phys-ew2.5.000
         fxrequired = AlwaysRequired
 	fxDONOTUSEurl = https://github.com/ESCOMP/atmospheric_physics
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -36,7 +36,8 @@
 [submodule "atmos_phys"]
 	path = src/atmos_phys
 	url = https://github.com/EarthWorksOrg/atmospheric_physics
-        fxtag = atmos_phys-ew2.5.000
+        # fxtag = atmos_phys-ew2.5.000
+        fxtag = fix/nvhpc_mem_leak_01
         fxrequired = AlwaysRequired
 	fxDONOTUSEurl = https://github.com/ESCOMP/atmospheric_physics
 

--- a/src/physics/rrtmgp/radiation.F90
+++ b/src/physics/rrtmgp/radiation.F90
@@ -1474,6 +1474,7 @@ subroutine radiation_tend( &
    call free_fluxes(fswc)
 
    call sources_lw%finalize()
+   call free_optics_lw(atm_optics_lw)
    call free_optics_lw(cloud_lw)
    call free_optics_lw(aer_lw)
    call free_fluxes(flw)


### PR DESCRIPTION
Reduce the memory lost during runs with the nvhpc/24.9 or nvhpc/24.11 stacks on Derecho. This includes making array assignment explicit (`tmp1(:,:) = tmp2(:,:)` instead of `tmp1 = tmp2`) and freeing memory at the end of `radiation_tend` from rrtmgp. 

Changes found by @johnmauff 